### PR TITLE
Feature: Millora del camp 'Origen' a les necessitats tècniques

### DIFF
--- a/src/components/tech_sheets/NeedsList.tsx
+++ b/src/components/tech_sheets/NeedsList.tsx
@@ -79,7 +79,8 @@ const NeedsList: React.FC<NeedsListProps> = ({
                 label=""
                 value={need.origin}
                 onChange={e => onListChange(listName, index, 'origin', e.target.value)}
-                placeholder="CIA / TÀG"
+                placeholder="Propi/Teatre/CIA/lloguer...."
+                readOnly={!!selectedMaterial}
               />
             </div>
             <div className="w-auto flex-shrink-0 pt-2">

--- a/src/components/tech_sheets/TechSheetField.tsx
+++ b/src/components/tech_sheets/TechSheetField.tsx
@@ -14,6 +14,7 @@ interface TechSheetFieldProps {
   required?: boolean;
   suggestions?: string[];
   disabled?: boolean;
+  readOnly?: boolean;
   infoText?: string;
   className?: string;
   tooltipText?: string;
@@ -32,14 +33,16 @@ const TechSheetField: React.FC<TechSheetFieldProps> = ({
   required = false,
   suggestions,
   disabled = false,
+  readOnly = false,
   infoText,
   className = '',
   tooltipText,
 }) => {
   const baseClasses = "mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm";
   const disabledClasses = "disabled:bg-gray-200 dark:disabled:bg-gray-600 disabled:cursor-not-allowed";
+  const readOnlyClasses = "read-only:bg-gray-100 dark:read-only:bg-gray-500";
 
-  const finalClassName = `${baseClasses} ${disabledClasses} ${className}`.trim();
+  const finalClassName = `${baseClasses} ${disabledClasses} ${readOnlyClasses} ${className}`.trim();
 
   const datalistId = suggestions ? `${id}-suggestions` : undefined;
 
@@ -57,6 +60,7 @@ const TechSheetField: React.FC<TechSheetFieldProps> = ({
           className={finalClassName}
           required={required}
           disabled={disabled}
+          readOnly={readOnly}
         />
       ) : (
         <input
@@ -71,6 +75,7 @@ const TechSheetField: React.FC<TechSheetFieldProps> = ({
           required={required}
           list={datalistId}
           disabled={disabled}
+          readOnly={readOnly}
         />
       )}
     </div>

--- a/src/components/tech_sheets/TechSheetForm.tsx
+++ b/src/components/tech_sheets/TechSheetForm.tsx
@@ -133,6 +133,7 @@ const TechSheetForm: React.FC<TechSheetFormProps> = ({ eventFrame }) => {
         if (field === 'description') {
             const matchedItem = materialItems.find(item => item.name === value);
             currentItem.materialItemId = matchedItem ? matchedItem.id : null;
+            currentItem.origin = matchedItem ? matchedItem.location : '';
         }
 
         newNeeds[index] = currentItem;


### PR DESCRIPTION
S'ha implementat una nova lògica per al camp 'Origen' a la secció de necessitats tècniques de les fitxes de bolo:

- Si es selecciona un material existent del gestor, el camp 'Origen' s'omple automàticament amb la seva ubicació i esdevé de només lectura.
- Si l'usuari introdueix un material nou manualment, el camp 'Origen' mostra un nou text de marcador de posició ('Propi/Teatre/CIA/lloguer....') i roman editable.